### PR TITLE
Move session secret to environment variable

### DIFF
--- a/app.js
+++ b/app.js
@@ -36,7 +36,7 @@ app.use('/', express.static(path.join(__dirname, 'public')));
 app.use(session({
 	saveUninitialized: true,
 	resave: true,
-	secret: 'temporarySuperSecretKey#¤%&'
+	secret: process.env.SESSION_SECRET,
 }));
 require('./config/passport')(passport);
 app.use(passport.initialize());


### PR DESCRIPTION
Saving secrets in code is bad, so I moved it to the environment instead. I also generated a new, more secure key. This will invalidate all previously generated cookies used to store session ID:s, but that should be OK.