### PR TITLE
Remove some console logs

### DIFF
--- a/dbimport/index.js
+++ b/dbimport/index.js
@@ -11,11 +11,10 @@ var mysql  = require('mysql');
 var mysqlcon = mysql.createConnection(''); //Add url here
 
 mysqlcon.connect(function(err){
-  if(err){
-    console.log('mysql Database connection error');
-  }else{
+  if (err) {
+    console.error('mysql Database connection error');
+  } else {
     console.log('mysql Database connection successful');
-    console.log(err)
   }
 });
 

--- a/public_scripts/search-components.js
+++ b/public_scripts/search-components.js
@@ -88,7 +88,6 @@ var SearchBox = React.createClass({
         this.setState({searching: false, error: true});
     }.bind(this);
 
-    console.log('Sending search for "' + query + '"');
     request.send();
   },
   handleCheckbox: function(event) {

--- a/routes/helpers.js
+++ b/routes/helpers.js
@@ -11,7 +11,7 @@ var isadmin = function(user) {
   var plsurl = "https://pls.datasektionen.se/api/user/" + user + "/dfunkt/admin";
   return new Promise(function (resolve) {
     request({uri: plsurl, method: 'GET'}, function (error, response, body) {
-      if(error) console.log('error:', error); 
+      if(error) console.error(error);
       if (body === "true") {
         resolve(true);
       } else {
@@ -39,7 +39,7 @@ exports.requireadmin = function(req, res, next) {
       denied(res);
     }
   }).catch(function(e) {
-    console.log(e);
+    console.error(e);
   });
 };
 

--- a/routes/index.js
+++ b/routes/index.js
@@ -12,7 +12,6 @@ router.get('/', function(req, res) {
     helpers.isadmin(req.user),
   ]).then(function(results) {
     var rolemandates = results[0];
-    console.log(rolemandates);
     var isadmin = results[1];
     res.render('index', {
       user: req.user,
@@ -20,7 +19,7 @@ router.get('/', function(req, res) {
       rolemandates: rolemandates,
     });
   }).catch(function(e) {
-    console.log(e);
+    console.error(e);
     res.status(403);
     res.send('error');
   });
@@ -46,7 +45,7 @@ router.get('/user/:kthid', function(req, res) {
           mandates: mandates,
         });
       }).catch(function(e) {
-        console.log(e);
+        console.error(e);
         res.status(403);
         res.send('error');
       });
@@ -102,7 +101,7 @@ function respondPositionWithRole(role, req, res) {
         groups,
       });
     }).catch(function (e) {
-      console.log(e);
+      console.error(e);
       res.status(403);
       res.send('error');
     });

--- a/routes/kthpeople.js
+++ b/routes/kthpeople.js
@@ -52,7 +52,7 @@ router.get('/search/:query', function(req, res) {
       res.send(results);
     }).catch(function(err) {
       res.render('error', err);
-      console.log(err);
+      console.error(err);
     });
 });
 module.exports = router;

--- a/routes/login.js
+++ b/routes/login.js
@@ -5,7 +5,6 @@ var router  = express.Router();
 
 
 router.get('/test', function(req, res) {
-	console.log(req.user);
 	res.send('test hello ' + req.user);
 });
 

--- a/routes/mandates.js
+++ b/routes/mandates.js
@@ -86,7 +86,7 @@ function zfingerUpdateUser(ugkthid, userToUpdate) {
         "to match zfinger user w/ ugkthid: " + zfingerUser.ugkthid +
         " (Different ugkthids. This should never happen! Our db must be corrupted).";
       debug(errMsg);
-      console.log("IMPORTANT: " + errMsg); // Because this should never ever happen
+      console.error("IMPORTANT: " + errMsg); // Because this should never ever happen
       return Promise.reject(errMsg);
     } else {
       userToUpdate.first_name = zfingerUser.first_name;

--- a/routes/users.js
+++ b/routes/users.js
@@ -55,7 +55,6 @@ router.get("/fix_nulls", helpers.requireadmin, function (req, res) {
     });
     Promise.all(updates)
     .then(fixed_names => {
-      console.log("fixed names");
       res.send(fixed_names)
     })
     .catch(err => res.send(err));


### PR DESCRIPTION
Also print errors using `console.error` because why not.

The biggest problem was, I think, printing `rolemandates` when getting the index page. During three months, about 15 gigabytes of logs were created, and they're mostly garbage.