### PR TITLE
Fix duplicated middle names

### DIFF
--- a/util/zfinger.js
+++ b/util/zfinger.js
@@ -13,10 +13,12 @@ function extractLastName(fullname) {
 }
 
 function zfingerParseUser(user) {
+  const first_name = user.givenName || extractFirstName(user.cn);
+  const last_name = user.displayName ? user.displayName.substring(first_name.length + 1) : extractLastName(user.cn);
   return {
     fullname: user.cn,
-    first_name: user.givenName || extractFirstName(user.cn),
-    last_name: user.sn || extractLastName(user.cn),
+    first_name,
+    last_name,
     kthid: user.uid,
     ugkthid: user.ugKthid,
   };


### PR DESCRIPTION
The problem seems to have been that we did get `givenName` from hodis, which contains both first names and middle names, but we do not get `sn` (which doesn't exist in hodis, but maybe it once existed in zfinger?), so instead we tried to extract the last name from `cn` by just removing what was before the first space (so it did remove middle names).

This fix isn't perfect, but should work better than before.

Also note that this will remove the (kthid) at the end of peoples' last names.